### PR TITLE
fixed virtual tensor copy for user kernels

### DIFF
--- a/sample/framework/vx_tensor.c
+++ b/sample/framework/vx_tensor.c
@@ -465,7 +465,7 @@ VX_API_ENTRY vx_status VX_API_CALL vxCopyTensorPatch(vx_tensor tensor, vx_size n
     }
 
     /* determine if virtual before checking for memory */
-    if (tensor->base.is_virtual == vx_true_e)
+    if (tensor->base.is_virtual == vx_true_e && tensor->base.is_accessible == vx_false_e)
     {
         /* User tried to access a "virtual" tensor. */
         VX_PRINT(VX_ZONE_ERROR, "Can not access a virtual tensor\n");


### PR DESCRIPTION
Current code fails for user kernels with tensor params, when graph has virtual tensors.