### PR TITLE
Feature: Check for submodules at configure time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,22 @@ if ( ${PROCESSOR_COUNT} LESS "1" )
 endif ( ${PROCESSOR_COUNT} LESS "1" )
 add_definitions( -DTARGET_NUM_CORES=${PROCESSOR_COUNT} )
 
+# Check submodules have been checked out.
+find_path(API_DOCS_PATH "include/VX/vx.h" HINTS "api-docs")
+find_path(CTS_PATH "openvx_cts_version.inc" HINTS "cts")
+find_path(NNEF_TOOLS_PATH "nnef_tools/__init__.py" HINTS "kernels/NNEF-Tools")
+if(
+    "${API_DOCS_PATH}" STREQUAL "API_DOCS_PATH-NOTFOUND"
+    OR "${CTS_PATH}" STREQUAL "CTS_PATH-NOTFOUND"
+    OR "${NNEF_TOOLS_PATH}" STREQUAL "NNEF_TOOLS_PATH-NOTFOUND"
+)
+    message(
+        FATAL_ERROR
+        "Repsoitory submodules, required for a correct build, could not be found or are empty. \
+        Have you checked out the repository's Git submodules (`git submodule update --init --recursive`)?"
+    )
+endif()
+
 # Framework IDE Folders Names
 set_property( GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "" )
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )


### PR DESCRIPTION
Many users who are not familiar with Git and C are attempting to build this implementation without checking out the Git submodules. They encounter build errors which they are unable to diagnose.

This PR adds a basic sanity check to CMake, to test if the submodules are present at configuration time. If the submodules are not present or do not appear to be in order, CMake will fail with an informative error message.

*Examples of issues raised by users unfamiliar who have not checked out submodules:*

- https://github.com/KhronosGroup/OpenVX-sample-impl/issues/14
- https://github.com/KhronosGroup/OpenVX-sample-impl/issues/36
- https://github.com/KhronosGroup/openvx-samples/issues/6 (Possibly attempting to use the OpenVX API with missing headers after a minced build of this implementation.)