### PR TITLE
Unittest fixes

### DIFF
--- a/libraries/debug/vx_debug_module.c
+++ b/libraries/debug/vx_debug_module.c
@@ -89,7 +89,6 @@ static vx_uint32 num_kernels = dimof(kernels);
             if (status == VX_SUCCESS)
             {
                 status = vxFinalizeKernel(kernel);
-                status |= vxReleaseKernel(&kernel);
                 if (status != VX_SUCCESS)
                 {
                     vxAddLogEntry((vx_reference)context, status, "Failed to finalize kernel[%u]=%s\n",k, kernels[k]->name);

--- a/libraries/extras/vx_extras_module.c
+++ b/libraries/extras/vx_extras_module.c
@@ -92,7 +92,6 @@ static vx_uint32 num_kernels = dimof(kernels);
             if (status == VX_SUCCESS)
             {
                 status = vxFinalizeKernel(kernel);
-                status |= vxReleaseKernel(&kernel);
                 if (status != VX_SUCCESS)
                 {
                     vxAddLogEntry((vx_reference)context, status, "Failed to finalize kernel[%u]=%s\n",k, kernels[k]->name);

--- a/sample/tests/vx_test.c
+++ b/sample/tests/vx_test.c
@@ -775,7 +775,6 @@ vx_status vx_test_framework_delay_graph(int argc, char *argv[])
                                     vxuCheckImage(context, images[1], 0xBE, &errors) == VX_SUCCESS &&
                                     vxuCheckImage(context, images[2], 0xBE, &errors) == VX_SUCCESS)
                                 {
-                                    ALARM("Passed!");
                                     status = VX_SUCCESS;
                                 }
                                 else


### PR DESCRIPTION
Two small fixes for the unittest. First one is cosmetic, but the second one fixes an actual bug in the debug and extras modules that causes the vxUnloadKernels call in the tests to fail.