### PR TITLE
Fix vxMinMaxLoc minCount/maxCount scalar type to VX_TYPE_SIZE

### DIFF
--- a/kernels/c_model/c_statistics.c
+++ b/kernels/c_model/c_statistics.c
@@ -97,7 +97,7 @@ vx_status vxMeanStdDev(vx_image input, vx_scalar mean, vx_scalar stddev)
 // nodeless version of the MinMaxLoc kernel
 static void analyzeMinMaxValue(vx_uint32 x, vx_uint32 y, vx_int64 v,
                                vx_int64 *pMinVal, vx_int64 *pMaxVal,
-                               vx_uint32 *pMinCount, vx_uint32 *pMaxCount,
+                               vx_size *pMinCount, vx_size *pMaxCount,
                                vx_array minLoc, vx_array maxLoc)
 {
     vx_coordinates2d_t loc;
@@ -157,8 +157,8 @@ vx_status vxMinMaxLoc(vx_image input, vx_scalar minVal, vx_scalar maxVal, vx_arr
     vx_df_image format;
     vx_int64 iMinVal = INT64_MAX;
     vx_int64 iMaxVal = INT64_MIN;
-    vx_uint32 iMinCount = 0;
-    vx_uint32 iMaxCount = 0;
+    vx_size iMinCount = 0;
+    vx_size iMaxCount = 0;
     vx_map_id map_id = 0;
     vx_status status = VX_SUCCESS;
 

--- a/kernels/venum/venum_statistics.c
+++ b/kernels/venum/venum_statistics.c
@@ -246,7 +246,7 @@ vx_status vxMeanStdDev(vx_image input, vx_scalar mean, vx_scalar stddev)
 // nodeless version of the MinMaxLoc kernel
 static void analyzeMinMaxValue(vx_uint32 x, vx_uint32 y, vx_int64 v,
                                vx_int64 *pMinVal, vx_int64 *pMaxVal,
-                               vx_uint32 *pMinCount, vx_uint32 *pMaxCount,
+                               vx_size *pMinCount, vx_size *pMaxCount,
                                vx_array minLoc, vx_array maxLoc)
 {
     vx_coordinates2d_t loc;
@@ -436,7 +436,7 @@ static void addLoc16(vx_uint32 y, vx_uint32 x, uint16x8_t *pvPred, vx_array arrL
 
 static void calcMinMaxLocu8(vx_uint8 *src_base, vx_imagepatch_addressing_t *src_addr,
                             vx_int64 *pMinVal, vx_int64 *pMaxVal,
-                            vx_uint32 *pMinCount, vx_uint32 *pMaxCount,
+                            vx_size *pMinCount, vx_size *pMaxCount,
                             vx_array minLoc, vx_array maxLoc)
 {
     vx_uint32 y, x;
@@ -447,8 +447,8 @@ static void calcMinMaxLocu8(vx_uint8 *src_base, vx_imagepatch_addressing_t *src_
     vx_uint32 w16 = (src_addr->dim_x >> 4) << 4;
     vx_int64 iMinVal = 0;
     vx_int64 iMaxVal = 0;
-    vx_uint32 iMinCount = 0;
-    vx_uint32 iMaxCount = 0;
+    vx_size iMinCount = 0;
+    vx_size iMaxCount = 0;
     for (y = 0; y < src_addr->dim_y; y++)
     {
         vx_uint8 *ptr_src = src_base + y * src_addr->stride_y;
@@ -546,7 +546,7 @@ static void calcMinMaxLocu8(vx_uint8 *src_base, vx_imagepatch_addressing_t *src_
 
 static void calcMinMaxLocs16(vx_int16 *src_base, vx_imagepatch_addressing_t *src_addr,
                              vx_int64 *pMinVal, vx_int64 *pMaxVal,
-                             vx_uint32 *pMinCount, vx_uint32 *pMaxCount,
+                             vx_size *pMinCount, vx_size *pMaxCount,
                              vx_array minLoc, vx_array maxLoc)
 {
     vx_uint32 y, x;
@@ -557,8 +557,8 @@ static void calcMinMaxLocs16(vx_int16 *src_base, vx_imagepatch_addressing_t *src
     vx_uint32 w16 = (src_addr->dim_x >> 4) << 4;
     vx_int64 iMinVal = 0;
     vx_int64 iMaxVal = 0;
-    vx_uint32 iMinCount = 0;
-    vx_uint32 iMaxCount = 0;
+    vx_size iMinCount = 0;
+    vx_size iMaxCount = 0;
     for (y = 0; y < src_addr->dim_y; y++)
     {
         vx_uint8 *ptr_src = (vx_uint8 *)src_base + y * src_addr->stride_y;
@@ -660,8 +660,8 @@ vx_status vxMinMaxLoc(vx_image input, vx_scalar minVal, vx_scalar maxVal, vx_arr
     vx_df_image format;
     vx_int64 iMinVal = INT64_MAX;
     vx_int64 iMaxVal = INT64_MIN;
-    vx_uint32 iMinCount = 0;
-    vx_uint32 iMaxCount = 0;
+    vx_size iMinCount = 0;
+    vx_size iMaxCount = 0;
     vx_map_id map_id = 0;
     vx_status status = VX_SUCCESS;
 

--- a/sample/framework/vx_graph.c
+++ b/sample/framework/vx_graph.c
@@ -699,26 +699,6 @@ void ownDestructGraph(vx_reference ref)
         }
         ownRemoveNodeInt(&graph->nodes[0]);
     }
-    /* Release virtual objects scoped to this graph so they do not outlive it (#52) */
-    {
-        vx_context context = graph->base.context;
-        vx_uint32 r;
-        for (r = 0u; r < context->num_references; r++)
-        {
-            vx_reference virt_ref = context->reftable[r];
-            if (virt_ref != NULL && virt_ref->is_virtual == vx_true_e && virt_ref->scope == (vx_reference)graph)
-            {
-                if (virt_ref->external_count > 0)
-                {
-                    ownReleaseReferenceInt(&virt_ref, virt_ref->type, VX_EXTERNAL, NULL);
-                }
-                else if (virt_ref->internal_count > 0)
-                {
-                    ownDecrementReference(virt_ref, VX_INTERNAL);
-                }
-            }
-        }
-    }
 #ifdef OPENVX_USE_PIPELINING
     graph->worker_stop = vx_true_e;
     graph->worker_running = vx_false_e;

--- a/sample/framework/vx_graph.c
+++ b/sample/framework/vx_graph.c
@@ -699,6 +699,26 @@ void ownDestructGraph(vx_reference ref)
         }
         ownRemoveNodeInt(&graph->nodes[0]);
     }
+    /* Release virtual objects scoped to this graph so they do not outlive it (#52) */
+    {
+        vx_context context = graph->base.context;
+        vx_uint32 r;
+        for (r = 0u; r < context->num_references; r++)
+        {
+            vx_reference virt_ref = context->reftable[r];
+            if (virt_ref != NULL && virt_ref->is_virtual == vx_true_e && virt_ref->scope == (vx_reference)graph)
+            {
+                if (virt_ref->external_count > 0)
+                {
+                    ownReleaseReferenceInt(&virt_ref, virt_ref->type, VX_EXTERNAL, NULL);
+                }
+                else if (virt_ref->internal_count > 0)
+                {
+                    ownDecrementReference(virt_ref, VX_INTERNAL);
+                }
+            }
+        }
+    }
 #ifdef OPENVX_USE_PIPELINING
     graph->worker_stop = vx_true_e;
     graph->worker_running = vx_false_e;

--- a/sample/targets/c_model/vx_minmaxloc.c
+++ b/sample/targets/c_model/vx_minmaxloc.c
@@ -136,7 +136,7 @@ static vx_status VX_CALLBACK vxMinMaxLocOutputValidator(vx_node node, vx_uint32 
     }
     if ((index == 5) || (index == 6))
     {
-        ptr->dim.scalar.type = VX_TYPE_UINT32;
+        ptr->dim.scalar.type = VX_TYPE_SIZE;
         status = VX_SUCCESS;
     }
     return status;

--- a/sample/targets/venum/vx_minmaxloc.c
+++ b/sample/targets/venum/vx_minmaxloc.c
@@ -134,7 +134,7 @@ static vx_status VX_CALLBACK vxMinMaxLocOutputValidator(vx_node node, vx_uint32 
     }
     if ((index == 5) || (index == 6))
     {
-        ptr->dim.scalar.type = VX_TYPE_UINT32;
+        ptr->dim.scalar.type = VX_TYPE_SIZE;
         status = VX_SUCCESS;
     }
     return status;


### PR DESCRIPTION
## Summary

The OpenVX 1.3 specification requires the `minCount` and `maxCount` parameters of `vxMinMaxLocNode` to be `VX_TYPE_SIZE` scalars:

> {min, max}Count: [Opt.] The number of detected {mins, maxes} in image. Type `VX_TYPE_SIZE`.

The sample implementation instead:

- computed the counts into `vx_uint32` locals in the `c_model` and `venum` statistics kernels, and
- declared the count output parameters as `VX_TYPE_UINT32` in the `MinMaxLoc` output validators.

On LP64 platforms (Linux/macOS/ARM64) `vx_size` is 8 bytes while `vx_uint32` is 4. When a spec-conformant client supplies a `VX_TYPE_SIZE` count scalar, `vxCopyScalar` dispatches on the scalar's declared type and performs an **8-byte read from a 4-byte source**, so the returned count is corrupted with adjacent stack bytes. This makes the `MinMaxLoc.OnRandom` conformance tests fail against the implementation once the CTS is updated to use the spec-correct `VX_TYPE_SIZE` scalar.

## Changes

- `kernels/c_model/c_statistics.c`: `analyzeMinMaxValue` count params and `iMinCount`/`iMaxCount` locals `vx_uint32` -> `vx_size`.
- `kernels/venum/venum_statistics.c`: same for `analyzeMinMaxValue`, `calcMinMaxLocu8`, `calcMinMaxLocs16` and the outer `vxMinMaxLoc` (internal NEON accumulators stay `uint32`; only the value carried to `vxCopyScalar` widens).
- `sample/targets/c_model/vx_minmaxloc.c` and `sample/targets/venum/vx_minmaxloc.c`: `MinMaxLoc` output validator for params 5/6 `VX_TYPE_UINT32` -> `VX_TYPE_SIZE`.

The framework node/vxu wrappers only pass the user-provided scalars through, so no other changes are required.

## Test plan

- Build the sample implementation and run `*MinMaxLoc*` conformance tests from a CTS checkout that creates the count scalars as `VX_TYPE_SIZE` (see KhronosGroup/OpenVX-cts#39), on x86_64 and ARM64.

Made with Cursor
