### PR TITLE
Fix unclosed brace in vxExecuteGraph when streaming is disabled

### DIFF
--- a/sample/framework/vx_graph.c
+++ b/sample/framework/vx_graph.c
@@ -2728,6 +2728,8 @@ static vx_status vxExecuteGraph(vx_graph graph, vx_uint32 depth)
         if (!any_pipeup)
             steady_done = vx_true_e;
     }
+#else
+    }
 #endif
 
     if (context->perf_enabled)


### PR DESCRIPTION
## Summary

- The streaming implementation (PR #69) introduced a `while` loop inside `#ifdef OPENVX_USE_STREAMING` in `vxExecuteGraph`, with a bare `{` in the `#else` path as a drop-in replacement
- The `}` closing the `while` body was inside the `#ifdef` block, leaving the bare `{` in the non-streaming path unclosed
- Any build without `-DOPENVX_USE_STREAMING=ON` failed at end-of-file with: `error: expected declaration or statement at end of input`

## Fix

Adds `#else` / `}` to close the bare block in the non-streaming path, matching the `}` that closes the `while` body in the streaming path.

## Test plan

- [ ] Build without streaming flags (e.g. Vision-only mode) — previously failed, should now compile
- [ ] Build with `-DOPENVX_USE_STREAMING=ON` — should continue to compile and pass conformance

🤖 Generated with [Claude Code](https://claude.com/claude-code)