### PR TITLE
Fix std::numeric_limits missing include for NNEF-Tools target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ env:
   OPENVX_DIR: ${{ github.workspace }}/install/Linux/x64/Debug
   VX_TEST_DATA_PATH: ${{ github.workspace }}/cts/test_data/
   # Full feature set built into a single library so one build serves every test.
-  # NNEF is included; the bundled NNEF-Tools submodule uses std::numeric_limits
-  # without including <limits>, so it is force-included for the C++ compile.
   OPENVX_FEATURES: >-
     -DOPENVX_CONFORMANCE_VISION=ON
     -DOPENVX_USE_ENHANCED_VISION=ON
@@ -61,7 +59,6 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="$OPENVX_DIR" \
             -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_LIBDIR=bin \
             -DBUILD_X64=1 \
-            -DCMAKE_CXX_FLAGS="-include limits" \
             $OPENVX_FEATURES
           make install -j$(nproc)
       - name: Build Conformance Test Suite
@@ -109,7 +106,6 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install/Linux/x64/Release" \
             -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_LIBDIR=bin \
             -DBUILD_X64=1 \
-            -DCMAKE_CXX_FLAGS="-include limits" \
             $OPENVX_FEATURES
           make install -j$(nproc)
       - name: Upload Release install artifact

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -43,6 +43,10 @@ FIND_SOURCES()
 file(GLOB OVX_SRC_NNEF_LIB "${CMAKE_SOURCE_DIR}/kernels/NNEF-Tools/parser/cpp/src/*.cpp")
 add_library (${TARGET_NAME} STATIC ${OVX_SRC_NNEF_LIB} )
 
+# NNEF-Tools uses std::numeric_limits without #include <limits>; modern GCC
+# no longer pulls it in transitively, so force-include it for this target.
+target_compile_options(${TARGET_NAME} PRIVATE -include limits)
+
 install ( TARGETS ${TARGET_NAME} 
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
## Summary

- `kernels/NNEF-Tools` uses `std::numeric_limits` without `#include <limits>`; modern GCC no longer pulls it in transitively, causing build failures
- Previously worked around by passing `-DCMAKE_CXX_FLAGS="-include limits"` globally in CI, which pollutes all targets and requires every downstream consumer to apply the same workaround
- Fix: add `target_compile_options(nnef-lib PRIVATE -include limits)` in `kernels/CMakeLists.txt`, scoped only to the affected target
- Remove the now-redundant `-DCMAKE_CXX_FLAGS="-include limits"` workaround from `ci.yml` (both Debug and Release build jobs)

## Test plan

- [ ] Build with `-DOPENVX_CONFORMANCE_NNEF_IMPORT=ON` — should compile without `-DCMAKE_CXX_FLAGS="-include limits"`
- [ ] CI passes without the global CXX flag workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)