### PR TITLE
Install NNEF-Tools parser headers alongside the sample impl

### DIFF
--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -47,10 +47,13 @@ add_library (${TARGET_NAME} STATIC ${OVX_SRC_NNEF_LIB} )
 # no longer pulls it in transitively, so force-include it for this target.
 target_compile_options(${TARGET_NAME} PRIVATE -include limits)
 
-install ( TARGETS ${TARGET_NAME} 
+install ( TARGETS ${TARGET_NAME}
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+
+install ( DIRECTORY ${CMAKE_SOURCE_DIR}/kernels/NNEF-Tools/parser/cpp/include/
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
 		  
 set_target_properties( ${TARGET_NAME} PROPERTIES FOLDER ${HELPER_FOLDER} )
 endif (OPENVX_CONFORMANCE_NNEF_IMPORT)

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -53,7 +53,7 @@ install ( TARGETS ${TARGET_NAME}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 
 install ( DIRECTORY ${CMAKE_SOURCE_DIR}/kernels/NNEF-Tools/parser/cpp/include/
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
+          DESTINATION include )
 		  
 set_target_properties( ${TARGET_NAME} PROPERTIES FOLDER ${HELPER_FOLDER} )
 endif (OPENVX_CONFORMANCE_NNEF_IMPORT)

--- a/sample/framework/vx_event_queue.c
+++ b/sample/framework/vx_event_queue.c
@@ -160,7 +160,7 @@ VX_API_ENTRY vx_status VX_API_CALL vxSendUserEvent(vx_context context, vx_uint32
     event.type = VX_EVENT_USER;
     event.timestamp = ownCaptureTime();
     event.app_value = id;
-    event.event_info.user_event.user_event_parameter = parameter;
+    event.event_info.user_event.user_event_parameter = (void *)parameter;
 
     return ownPipelinePostEvent(context, &event);
 }


### PR DESCRIPTION
## Summary

- `cnnef.h` and the `nnef/` headers from `kernels/NNEF-Tools/parser/cpp/include/` are used directly by CTS test sources (`test_nnef_import.c`) but were not installed by `make install`
- Downstream consumers had to pass a separate `-I` pointing into the sample impl source tree to find them
- Add an `install(DIRECTORY)` rule so the headers land in `$OPENVX_DIR/include/` alongside the OpenVX headers — reachable via the standard `OPENVX_INCLUDES` path

## Test plan

- [ ] Build with `-DOPENVX_CONFORMANCE_NNEF_IMPORT=ON` and `make install`
- [ ] Verify `cnnef.h` appears under `$OPENVX_DIR/include/`
- [ ] Build CTS against the install without any extra `-I` flag — should compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)